### PR TITLE
Better error messages when not finding name or distributed cookie on config file

### DIFF
--- a/priv/bin_script
+++ b/priv/bin_script
@@ -119,6 +119,8 @@ if [ -z "$COOKIE_ARG" ]; then
     COOKIE=`egrep '^[ \t]*distributed_cookie[ \t]*=[ \t]*' $RUNNER_ETC_DIR/$CUTTLEFISH_CONF 2> /dev/null | cut -d = -f 2 | tr -d ' '`
     if [ -z "$COOKIE" ]; then
         echo "vm.args needs to have a -setcookie parameter."
+        echo "  couldn't find 'distributed_cookie' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
+        echo "  \$PWD is $PWD"
         exit 1
     else
         COOKIE_ARG="-setcookie $COOKIE"

--- a/priv/bin_script
+++ b/priv/bin_script
@@ -102,6 +102,8 @@ if [ -z "$NAME_ARG" ]; then
     if [ -z "$NODENAME" ]; then
         echo "vm.args needs to have a -name parameter."
         echo "  -sname is not supported."
+        echo "  couldn't find 'nodename' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
+        echo "  \$PWD is $PWD"
         exit 1
     else
         NAME_TYPE="-name"


### PR DESCRIPTION
Now when trying to extract nodename and distributed_cookie from cuttlefish conf and failing the error is quite cryptic:

```
$ ./_build/prod/rel/td/bin/td console
vm.args needs to have a -name parameter.
  -sname is not supported.
```

with this changes more context is added about what when wrong and where it was trying to look for the files (the error can happen because the conf is not there)

```
$ ./_build/prod/rel/td/bin/td console
vm.args needs to have a -name parameter.
  -sname is not supported.
  couldn't find 'nodename' in ../td_config/td.conf
  $PWD is /home/mariano/tmp/td
```

NOTE: I think I should change vm.args in the error to $RUNNER_ETC_DIR/$CUTTLEFISH_CONF what do you think?
