### PR TITLE
fix bin paths if cuttlefish is only found in _checkouts

### DIFF
--- a/src/rebar3_cuttlefish_release.erl
+++ b/src/rebar3_cuttlefish_release.erl
@@ -39,7 +39,8 @@ do(State) ->
                  true ->
                      filename:join([rebar_dir:base_dir(State), "bin", "cuttlefish"]);
                  false ->
-                     case filelib:wildcard(filename:join(["_build", "*", "bin", "cuttlefish"])) of
+                     case filelib:wildcard(filename:join(["_build", "*", "bin", "cuttlefish"])) ++
+                          filelib:wildcard(filename:join(["_checkouts", "cuttlefish*", "cuttlefish"])) of
                          [C | _] ->
                              C;
                          [] ->


### PR DESCRIPTION
Fixes path to the bin script if cuttlefish is located in _checkouts, which is handy when developing this plugin
