### PR TITLE
Added 'config' command to the bin_script from riak

### DIFF
--- a/priv/bin_script
+++ b/priv/bin_script
@@ -238,7 +238,7 @@ case "$1" in
         fi
         ;;
 
-config)
+    config)
         shift
         case "$1" in
             effective) ## Great, pass through!

--- a/priv/bin_script
+++ b/priv/bin_script
@@ -102,6 +102,8 @@ if [ -z "$NAME_ARG" ]; then
     if [ -z "$NODENAME" ]; then
         echo "vm.args needs to have a -name parameter."
         echo "  -sname is not supported."
+        echo "  couldn't find 'nodename' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
+        echo "  \$PWD is $PWD"
         exit 1
     else
         NAME_TYPE="-name"
@@ -117,6 +119,8 @@ if [ -z "$COOKIE_ARG" ]; then
     COOKIE=`egrep '^[ \t]*distributed_cookie[ \t]*=[ \t]*' $RUNNER_ETC_DIR/$CUTTLEFISH_CONF 2> /dev/null | cut -d = -f 2 | tr -d ' '`
     if [ -z "$COOKIE" ]; then
         echo "vm.args needs to have a -setcookie parameter."
+        echo "  couldn't find 'distributed_cookie' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
+        echo "  \$PWD is $PWD"
         exit 1
     else
         COOKIE_ARG="-setcookie $COOKIE"

--- a/priv/bin_script
+++ b/priv/bin_script
@@ -102,8 +102,6 @@ if [ -z "$NAME_ARG" ]; then
     if [ -z "$NODENAME" ]; then
         echo "vm.args needs to have a -name parameter."
         echo "  -sname is not supported."
-        echo "  couldn't find 'nodename' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
-        echo "  \$PWD is $PWD"
         exit 1
     else
         NAME_TYPE="-name"
@@ -119,8 +117,6 @@ if [ -z "$COOKIE_ARG" ]; then
     COOKIE=`egrep '^[ \t]*distributed_cookie[ \t]*=[ \t]*' $RUNNER_ETC_DIR/$CUTTLEFISH_CONF 2> /dev/null | cut -d = -f 2 | tr -d ' '`
     if [ -z "$COOKIE" ]; then
         echo "vm.args needs to have a -setcookie parameter."
-        echo "  couldn't find 'distributed_cookie' in $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
-        echo "  \$PWD is $PWD"
         exit 1
     else
         COOKIE_ARG="-setcookie $COOKIE"
@@ -145,7 +141,6 @@ else
     echo "Cuttlefish failed! Oh no!"
     exit 1
 fi
-
 
 # User can specify an sname without @hostname
 # This will fail when creating remote shell
@@ -237,6 +232,32 @@ case "$1" in
         if ! relx_nodetool "ping"; then
             exit 1
         fi
+        ;;
+
+config)
+        shift
+        case "$1" in
+            effective) ## Great, pass through!
+                ;;
+            describe)
+                if [ $# -lt 2 ] || [ "$2" = "-l" ]; then
+                    echo "$RUNNER_SCRIPT config describe requires a variable name to query"
+                    echo "  Try \`$RUNNER_SCRIPT config describe setting.name\`"
+                    exit 1
+                fi
+                ;;
+            generate) ## Great, pass through!
+                ;;
+            *)
+                echo "Valid commands for$RUNNER_SCRIPT config are:"
+                echo "  $RUNNER_SCRIPT config effective"
+                echo "  $RUNNER_SCRIPT config describe VARIABLE"
+                exit 1
+                ;;
+        esac
+
+        CUTTLEFISH_COMMAND_PREFIX="$RUNNER_BASE_DIR/bin/cuttlefish -e $RUNNER_ETC_DIR -s $RUNNER_BASE_DIR/share/schema -d $RUNNER_BASE_DIR/generated.configs -c $RUNNER_ETC_DIR/cse_spooler.conf"
+        printf '%s \n' "`$CUTTLEFISH_COMMAND_PREFIX $@`"
         ;;
 
     escript)
@@ -400,7 +421,7 @@ case "$1" in
         ;;
 
     *)
-        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|rpc|rpcterms}"
+        echo "Usage: $REL_NAME {start|start_boot <file>|foreground|stop|restart|reboot|pid|ping|console|console_clean|console_boot <file>|attach|remote_console|upgrade|config|escript|rpc|rpcterms}"
         exit 1
         ;;
 esac


### PR DESCRIPTION
To support the config command and sub commands I modified the bin_script to include the config command which allows a user to view the current cuttlefish parameter values and to see the description and default for a given param.

This is pulled from the riak escript and updated with the proper variables in the existing bin_script.
