### PR TITLE
if RUNNER_ETC_DIR is relative make it relative to RELEASE_ROOT_DIR

### DIFF
--- a/priv/bin_script
+++ b/priv/bin_script
@@ -20,6 +20,12 @@ RUNNER_BASE_DIR=$RELEASE_ROOT_DIR
 RUNNER_ETC_DIR="${RUNNER_ETC_DIR:-{{ platform_etc_dir }}}"
 RUNNER_ETC_DIR="${RUNNER_ETC_DIR:-$RELEASE_ROOT_DIR/etc}"
 
+if [ "$RUNNER_ETC_DIR" = "${RUNNER_ETC_DIR#/}" ]
+then
+    # if relative, make it relative to RELEASE_ROOT_DIR
+    RUNNER_ETC_DIR=$RELEASE_ROOT_DIR/$RUNNER_ETC_DIR
+fi # else absolute, keep it as it is
+
 find_erts_dir() {
     __erts_dir="$RELEASE_ROOT_DIR/erts-$ERTS_VSN"
     if [ -d "$__erts_dir" ]; then


### PR DESCRIPTION
this solves the corner case specified in https://github.com/tsloughter/rebar3_cuttlefish/pull/12#issuecomment-220320780

and the reason for this PR https://github.com/tsloughter/rebar3_cuttlefish/pull/17

if RUNNER_ETC_DIR is absolute be it because:
- it was set as absolute in platform_etc_dir or
- becase platform_etc_dir wasn't set and was expanded to $RELEASE_ROOT_DIR/etc

then it will be left as is, but if RUNNER_ETC_DIR is relative (because
it as set as relative in platform_etc_dir), then it will be made
absolute relative to $RELEASE_ROOT_DIR, instead of relative to the place
where the application was started.

this will fix problems like this ones:

https://github.com/marianoguerra/tanodb/issues/7
https://github.com/marianoguerra/tanodb/issues/6

and remove the need for hacks like this one: https://github.com/marianoguerra/rebar3_template_riak_core/blob/master/rebar3_riak_core_Makefile.tpl#L11

and will make `rebar3 run` work out of the box even when RUNNER_ETC_DIR is relative.
