### PR TITLE
replaced hardcoded config file name with $CUTTLEFISH_CONF

### DIFF
--- a/priv/bin_script
+++ b/priv/bin_script
@@ -272,7 +272,7 @@ case "$1" in
                 ;;
         esac
 
-        CUTTLEFISH_COMMAND_PREFIX="$RUNNER_BASE_DIR/bin/cuttlefish -e $RUNNER_ETC_DIR -s $RUNNER_BASE_DIR/share/schema -d $RUNNER_BASE_DIR/generated.configs -c $RUNNER_ETC_DIR/cse_spooler.conf"
+        CUTTLEFISH_COMMAND_PREFIX="$RUNNER_BASE_DIR/bin/cuttlefish -e $RUNNER_ETC_DIR -s $RUNNER_BASE_DIR/share/schema -d $RUNNER_BASE_DIR/generated.configs -c $RUNNER_ETC_DIR/$CUTTLEFISH_CONF"
         printf '%s \n' "`$CUTTLEFISH_COMMAND_PREFIX $@`"
         ;;
 


### PR DESCRIPTION
I inadvertently left a hardcoded filename in the bin_script from my testing when I originally added the 'config' option, my bad.
