### PR TITLE
Generate config only if we need it, do not generate for commands like remote_console/ping

### DIFF
--- a/priv/bin_script
+++ b/priv/bin_script
@@ -154,13 +154,21 @@ CUTTLEFISHCMD="$ERTS_DIR/bin/escript $RUNNER_BASE_DIR/bin/cuttlefish"
 
 cd "$ROOTDIR"
 
-if CUTTLEFISH_CONFIG=$($CUTTLEFISHCMD -e $RUNNER_ETC_DIR -d $RUNNER_BASE_DIR/generated.conf -s $RUNNER_BASE_DIR/share/schema/ -c $RUNNER_ETC_DIR/$CUTTLEFISH_CONF.new)
-then
-    CONFIG_FILES="$CUTTLEFISH_CONFIG"
-else
-    echo "Cuttlefish failed! Oh no!"
-    exit 1
-fi
+# Generate new config only if we need it
+case "$1" in
+    console|console_clean|console_boot|foreground)
+        if CUTTLEFISH_CONFIG=$($CUTTLEFISHCMD -e $RUNNER_ETC_DIR -d $RUNNER_BASE_DIR/generated.conf -s $RUNNER_BASE_DIR/share/schema/ -c $RUNNER_ETC_DIR/$CUTTLEFISH_CONF.new)
+        then
+            CONFIG_FILES="$CUTTLEFISH_CONFIG"
+        else
+            echo "Cuttlefish failed! Oh no!"
+            exit 1
+        fi
+        ;;
+    *)
+        # Do not generate config
+        ;;
+esac
 
 # User can specify an sname without @hostname
 # This will fail when creating remote shell


### PR DESCRIPTION
Cuttlefish generates new config (and delete old) when we run any command, even if new config files are not required.
I start app with 'bin/appname start' command. Cuttlefish generates new config in generated.conf and application starts with this config.
Then I use remote_console/ping to check my app. 
For each call remote_console (and any other command) Cuttlefish generates new config again and deletes the old config files (when we have more than max_history files).
As a result after several remote_console command Cuttlefish deletes config which was created during the app start.
We do not restart app but config files have been deleted.
So we do not know exactly which config was used for the app start.