### PR TITLE
Upgrade cuttlefish (another OTP20 thing)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,2 +1,4 @@
 {erl_opts, [debug_info]}.
-{deps, [{cuttlefish, "~> 2.0"}]}.
+{deps, [
+        {cuttlefish, {git,"git://github.com/kyorai/cuttlefish.git", {branch, "develop"}}}
+       ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,14 @@
 {"1.1.0",
-[{<<"cuttlefish">>,{pkg,<<"cuttlefish">>,<<"2.0.12">>},0},
+[{<<"cuttlefish">>,
+  {git,"git://github.com/kyorai/cuttlefish.git",
+       {ref,"649cda2828ef939126a20faa5d0ee0a2ab69f9a6"}},
+  0},
  {<<"getopt">>,{pkg,<<"getopt">>,<<"0.8.2">>},1},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},2},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},1}]}.
+ {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.8">>},2},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.2.1">>},1}]}.
 [
 {pkg_hash,[
- {<<"cuttlefish">>, <<"1441A12BCE207F7FC796A4DA50D47080D21E83E15309AD6496DE27840A54D5FC">>},
  {<<"getopt">>, <<"B17556DB683000BA50370B16C0619DF1337E7AF7ECBF7D64FBF8D1D6BCE3109B">>},
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>}]}
+ {<<"goldrush">>, <<"2024BA375CEEA47E27EA70E14D2C483B2D8610101B4E852EF7F89163CDB6E649">>},
+ {<<"lager">>, <<"EEF4E18B39E4195D37606D9088EA05BF1B745986CF8EC84F01D332456FE88D17">>}]}
 ].


### PR DESCRIPTION
So we just ran into another issue which was being shadowed by (I think) us also having the cuttlefish as a dependency. The issue is that that the rebar3_cuttlefish plugin pulls in the cuttlefish version which still uses `-smp disable` which doesn't work on OTP20, and sometimes that cuttlefish version would end in `_build/default/bin/cuttlefish` instead of the one in our deps. Not sure exactly why this only happens for some people and not always, though.

I guess it would be nicer if a new cuttlefish release was published to hex.pm so we could reference it there instead of directly on github.

I apologize for all these drop-wise OTP20 PRs...