### PR TITLE
Add ability to specify schema order as well as using schema discovery.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,32 @@ $ _build/node<#>/rel/<name>/bin/<name> console
 ## Optional Ordering of Schemas
 
 Since cuttlefish uses sort order of the schema files by their name you may want to prepend a number to the schema file name, like `01-eleveldb.schema`. While the plugin will automatically copy all schema files for you it will first check if there is already an overlay entry for each schema file. So if in `overlay` there is an entry `{template, "schema/eleveldb.schema", "01-eleveldb.schema"}` it will not make another copy.
+
+Alternatively, we can specify the ordering of discovered schemas in the rebar.config by setting schema_order in our cuttlefish configuration. This will handle the prefixing for you and the discovered schemas will be ordered as per the order specified in the list. Any discovered schemas that are not in the list will be copied over as-is (with no ordering prefix).
+
+```erlang
+{cuttlefish,
+ [{file_name, "<release>.conf.example"},
+  {schema_discovery, true},
+  {schema_order, [
+    riak
+    erlang_vm
+    riak_core
+  ]}
+]}.
+```
+Discovered schemas:
+```erlang
+riak.schema
+erlang_vm.schema
+riak_core.schema
+riak_repl.schema
+```
+
+Resulting copied schemas:
+```erlang
+10-riak.schema
+11-erlang_vm.schema
+12-riak_core.schema
+riak_repl.schema (not specified in ordering)
+```

--- a/src/rebar3_cuttlefish_release.erl
+++ b/src/rebar3_cuttlefish_release.erl
@@ -134,7 +134,7 @@ schemas(Apps) ->
                       filelib:wildcard(filename:join([Dir, "{priv,schema}", "*.schema"]))
                   end, Apps) ++ filelib:wildcard(filename:join(["{priv,schema}", "*.schema"])).
 
-overlays(_Name, Cuttlefish, Overlays, Schemas, OrderSchemas) ->
+overlays(Name, Cuttlefish, Overlays, Schemas, OrderSchemas) ->
     BinScriptTemplate = filename:join([code:priv_dir(rebar3_cuttlefish), "bin_script"]),
     NodeTool = filename:join([code:priv_dir(rebar3_cuttlefish), "nodetool"]),
     InstallUpgrade = filename:join([code:priv_dir(rebar3_cuttlefish), "install_upgrade_escript"]),

--- a/src/rebar3_cuttlefish_release.erl
+++ b/src/rebar3_cuttlefish_release.erl
@@ -67,11 +67,6 @@ do(State) ->
                        _ -> false
                    end,
 
-    DisableCFRelScripts = case lists:keyfind(disable_bin_scripts, 1, CFConf) of
-                              {disable_bin_scripts, true} -> true;
-                              _ -> false
-                          end,
-
     Overlays1 = case {lists:keyfind(schema_discovery, 1, CFConf),
                       lists:keyfind(overlay, 1, Relx)} of
                     {{schema_discovery, false}, {overlay, Overlays}} ->


### PR DESCRIPTION
This adds an option for being able to specify an ordering of schema files when discovery is enabled, rather than having to pollute the relx config with a bunch of copy directives for schemas.

Basically, in the cuttlefish plugin config section, we can specify a schema_order for any of the schemas that we are aware of, and wants to prioritise:

```
{cuttlefish, [                  
    {file_name, "riak.conf"},   
    {schema_discovery, true},   
    {schema_order, [            
        riak,                   
        erlang_vm,              
        riak_core,              
        riak_api,               
        riak_kv,                
        riak_sysmon,            
        bitcask,                
        bitcask_multi,          
        eleveldb,               
        eleveldb_multi,         
        multi_backend           
    ]}                          
]}.                             
```

Discovered schemas:

```
riak.schema
erlang_vm.schema
riak_core.schema
riak_api.schema
riak_kv.schema
riak_sysmon.schema
bitcask.schema
bitcask_multi.schema
eleveldb.schema
eleveldb_multi.schema 
multi_backend.schema
riak_repl.schema
yokozuna.schema
```

Copied schemas:

```
10-riak.schema
11-erlang_vm.schema
12-riak_core.schema
13-riak_api.schema
14-riak_kv.schema
15-riak_sysmon.schema
16-bitcask.schema
17-bitcask_multi.schema
18-eleveldb.schema
19-eleveldb_multi.schema 
20-multi_backend.schema
riak_repl.schema (not specified in ordering)
yokozuna.schema (not specified in ordering)
```

The change basically takes the discovered schemas and prefixes them based on the ordering specified in our config. If we do not specify a discovered schema in the ordering, it will not be indexed (prefixed with "10-"+), but will still be copied over to share/schemas.