### PR TITLE
Disable rebar3_cuttlefish bundled bin script

### DIFF
--- a/priv/cf_config
+++ b/priv/cf_config
@@ -8,8 +8,9 @@ then
     CONFIG_PATH=$(echo $CUTTLE_CONF | sed -E 's/.*-config ([^ ]+).*/\1/')
     VMARGS_PATH=$(echo $CUTTLE_CONF | sed -E 's/.*-vm_args ([^ ]+).*/\1/')
 
+    RELX_CONFIG_PATH=releases/{{release_version}}/sys.config
     ln -sf $VMARGS_PATH releases/{{release_version}}/vm.args
-    ln -sf $CONFIG_PATH releases/{{release_version}}/sys.config
+    ln -sf $CONFIG_PATH $RELX_CONFIG_PATH
 else
     echo "Cuttlefish failed! Oh no!: $CUTTLEFISH_CONFIG"
     exit 1

--- a/priv/cf_config
+++ b/priv/cf_config
@@ -1,0 +1,28 @@
+RUNNER_ETC_DIR=($RELEASE_ROOT_DIR"/etc")
+CUTTLEFISHCMD="$ERTS_DIR/bin/escript $RELEASE_ROOT_DIR/bin/cuttlefish"
+
+if CUTTLE_CONF=$($CUTTLEFISHCMD -e $RUNNER_ETC_DIR -d "generated.configs" -s "$RELEASE_ROOT_DIR/share/schema/" -c "$RUNNER_ETC_DIR/{{release_name}}.conf")
+then
+    RELX_CONFIG_PATH=$(sed 's/\.config$//' <<< $(awk -F"-config |-args_file |-vm_args " '{print $2}' <<< $CUTTLE_CONF))
+    VMARGS_PATH=$(awk -F"-config | -args_file | -vm_args " '{print $3}' <<< $CUTTLE_CONF)
+
+    ln -sf $VMARGS_PATH releases/{{release_version}}/vm.args
+else
+    echo "Cuttlefish failed! Oh no!: $CUTTLEFISH_CONFIG"
+    exit 1
+fi
+
+NODENAME=`egrep '^[ \t]*nodename[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/{{release_name}}.conf" 2> /dev/null | tail -n 1 | cut -d = -f 2`
+if [ -z "$NODENAME" ]; then
+    echo "vm.args needs to have a -name parameter."
+    echo "  -sname is not supported."
+    exit 1
+else
+    NAME_TYPE="-name"    
+    NAME="${NODENAME# *}"
+    export NAME
+
+    PIPE_DIR="/tmp/erl_pipes/$NAME/"
+    mkdir -p "$PIPE_DIR"
+    export PIPE_DIR
+fi

--- a/priv/cf_config
+++ b/priv/cf_config
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-RUNNER_ETC_DIR=($RELEASE_ROOT_DIR"/etc")
+RUNNER_ETC_DIR=$RELEASE_ROOT_DIR"/etc"
 CUTTLEFISHCMD="$ERTS_DIR/bin/escript $RELEASE_ROOT_DIR/bin/cuttlefish"
 
 if CUTTLE_CONF=$($CUTTLEFISHCMD -e $RUNNER_ETC_DIR -d "generated.configs" -s "$RELEASE_ROOT_DIR/share/schema/" -c "$RUNNER_ETC_DIR/{{release_name}}.conf")

--- a/priv/cf_config
+++ b/priv/cf_config
@@ -1,12 +1,15 @@
+#!/bin/sh
+
 RUNNER_ETC_DIR=($RELEASE_ROOT_DIR"/etc")
 CUTTLEFISHCMD="$ERTS_DIR/bin/escript $RELEASE_ROOT_DIR/bin/cuttlefish"
 
 if CUTTLE_CONF=$($CUTTLEFISHCMD -e $RUNNER_ETC_DIR -d "generated.configs" -s "$RELEASE_ROOT_DIR/share/schema/" -c "$RUNNER_ETC_DIR/{{release_name}}.conf")
 then
-    RELX_CONFIG_PATH=$(sed 's/\.config$//' <<< $(awk -F"-config |-args_file |-vm_args " '{print $2}' <<< $CUTTLE_CONF))
-    VMARGS_PATH=$(awk -F"-config | -args_file | -vm_args " '{print $3}' <<< $CUTTLE_CONF)
+    CONFIG_PATH=$(echo $CUTTLE_CONF | sed -E 's/.*-config ([^ ]+).*/\1/')
+    VMARGS_PATH=$(echo $CUTTLE_CONF | sed -E 's/.*-vm_args ([^ ]+).*/\1/')
 
     ln -sf $VMARGS_PATH releases/{{release_version}}/vm.args
+    ln -sf $CONFIG_PATH releases/{{release_version}}/sys.config
 else
     echo "Cuttlefish failed! Oh no!: $CUTTLEFISH_CONFIG"
     exit 1

--- a/src/rebar3_cuttlefish_release.erl
+++ b/src/rebar3_cuttlefish_release.erl
@@ -97,9 +97,7 @@ do(State) ->
 
     StartHookState = maybe_set_startup_hook(DisableCFRelScripts, State),
     State1 = rebar_state:set(State, relx, lists:keydelete(overlay, 1, Relx) ++
-                                 [{sys_config, false},
-                                  {vm_args, DisableCFRelScripts},
-                                  {generate_start_script, DisableCFRelScripts},
+                                 [{generate_start_script, DisableCFRelScripts},
                                   {overlay, Overlays3} | StartHookState]),
     Res = rebar_relx:do(rlx_prv_release, "release", ?PROVIDER, State1),
     SchemaGlob = filename:join([TargetDir, "share", "schema", "*.schema"]),
@@ -174,7 +172,7 @@ overlay_add_bin_scripts(false, Name, Overlays) ->
      {template, BinScriptTemplate, BinScript} | Overlays].
 
 maybe_set_startup_hook(false, _State) ->
-    [];
+    [{sys_config, false}, {vm_args, false}];
 maybe_set_startup_hook(true, State) ->
     RelxState = rebar_state:get(State, relx),
     StartHooks0 = 

--- a/src/rebar3_cuttlefish_release.erl
+++ b/src/rebar3_cuttlefish_release.erl
@@ -61,6 +61,11 @@ do(State) ->
     {ok, Cuttlefish} = rebar_app_utils:find(<<"cuttlefish">>, rebar_state:all_plugin_deps(State)),
     AllSchemas = schemas([Cuttlefish | Deps++Apps]),
 
+    DisableCFRelScripts = case lists:keyfind(disable_bin_scripts, 1, CFConf) of
+                              {disable_bin_scripts, true} -> true;
+                              _ -> false
+                          end,
+
     Overlays1 = case {lists:keyfind(schema_discovery, 1, CFConf),
                       lists:keyfind(overlay, 1, Relx)} of
                     {{schema_discovery, false}, {overlay, Overlays}} ->
@@ -73,19 +78,23 @@ do(State) ->
                         overlays(Name, CuttlefishBin, [], AllSchemas)
                 end,
 
+    Overlays2 = overlay_add_bin_scripts(DisableCFRelScripts, Name, Overlays1),
+
     ConfFile = filename:join("config", atom_to_list(Name)++".conf"),
 
-    Overlays2 = case filelib:is_regular(ConfFile) of
+    Overlays3 = case filelib:is_regular(ConfFile) of
                     true ->
-                        [{template, ConfFile, "etc/" ++ CFFile} | Overlays1];
+                        [{template, ConfFile, "etc/" ++ CFFile} | Overlays2];
                     false ->
-                        Overlays1
+                        Overlays2
                 end,
+
+    StartHookState = maybe_set_startup_hook(DisableCFRelScripts, State),
     State1 = rebar_state:set(State, relx, lists:keydelete(overlay, 1, Relx) ++
                                  [{sys_config, false},
-                                  {vm_args, false},
-                                  {generate_start_script, false},
-                                  {overlay, Overlays2}]),
+                                  {vm_args, DisableCFRelScripts},
+                                  {generate_start_script, DisableCFRelScripts},
+                                  {overlay, Overlays3} | StartHookState]),
     Res = rebar_relx:do(rlx_prv_release, "release", ?PROVIDER, State1),
     SchemaGlob = filename:join([TargetDir, "share", "schema", "*.schema"]),
     ReleaseSchemas = filelib:wildcard(SchemaGlob),
@@ -123,20 +132,50 @@ schemas(Apps) ->
                       filelib:wildcard(filename:join([Dir, "{priv,schema}", "*.schema"]))
                   end, Apps) ++ filelib:wildcard(filename:join(["{priv,schema}", "*.schema"])).
 
-overlays(Name, Cuttlefish, Overlays, Schemas) ->
-    BinScriptTemplate = filename:join([code:priv_dir(rebar3_cuttlefish), "bin_script"]),
-    NodeTool = filename:join([code:priv_dir(rebar3_cuttlefish), "nodetool"]),
-    InstallUpgrade = filename:join([code:priv_dir(rebar3_cuttlefish), "install_upgrade_escript"]),
-    BinScript = filename:join(["bin", Name]),
+overlays(_Name, Cuttlefish, Overlays, Schemas) ->
     Overlays1 = [ list_to_binary(F) || {_, F, _} <- Overlays],
     SchemaOverlays = [{template, Schema, filename:join(["share", "schema", filename:basename(Schema)])}
                       || Schema <- Schemas, not is_overlay(Schema, Overlays1)],
     [{copy, Cuttlefish, "bin/cuttlefish"},
      {mkdir, "share"},
-     {mkdir, "share/schema"},
-     {copy, NodeTool, filename:join(["bin", "nodetool"])},
+     {mkdir, "share/schema"} | SchemaOverlays].
+
+overlay_add_bin_scripts(true, _Name, Overlays) ->
+    CFConfigHookTemplate = filename:join([code:priv_dir(rebar3_cuttlefish), "cf_config"]),
+    [{template, CFConfigHookTemplate, filename:join(["bin", "cf_config"])} | Overlays];
+overlay_add_bin_scripts(false, Name, Overlays) ->
+    BinScriptTemplate = filename:join([code:priv_dir(rebar3_cuttlefish), "bin_script"]),
+    NodeTool = filename:join([code:priv_dir(rebar3_cuttlefish), "nodetool"]),
+    InstallUpgrade = filename:join([code:priv_dir(rebar3_cuttlefish), "install_upgrade_escript"]),
+    BinScript = filename:join(["bin", Name]),
+    [{copy, NodeTool, filename:join(["bin", "nodetool"])},
      {copy, InstallUpgrade, filename:join(["bin", "install_upgrade.escript"])},
-     {template, BinScriptTemplate, BinScript} | SchemaOverlays].
+     {template, BinScriptTemplate, BinScript} | Overlays].
+
+maybe_set_startup_hook(false, _State) ->
+    [];
+maybe_set_startup_hook(true, State) ->
+    RelxState = rebar_state:get(State, relx),
+    StartHooks0 = 
+        case lists:keyfind(extended_start_script_hooks, 1, RelxState) of
+            {extended_start_script_hooks, StartHooks1} ->
+                do_set_start_hook(StartHooks1);
+            _ ->
+                do_set_start_hook([])
+        end,
+    [{extended_start_script, true},
+     {extended_start_script_hooks, StartHooks0}].
+
+do_set_start_hook(StartHooks) ->
+    CFPreStart = {custom, "cf_config"},
+    PreStart =
+        case lists:keyfind(pre_start, 1, StartHooks) of
+            {pre_start, PreStartHooks} ->
+                [CFPreStart | PreStartHooks];
+            _ ->
+                [CFPreStart]
+        end,
+    lists:keystore(pre_start, 1, StartHooks, {pre_start, PreStart}).
 
 is_overlay(SchemaS, Overlays) ->
     Schema = list_to_binary(SchemaS),


### PR DESCRIPTION
I wanted to take advantage of the features in relx that are not in the old, copied start script that has been bundled with the plugin. We could ultimately re-copy the newer relx script and apply the same cuttlefish-required changes to make it compatible, but I thought it might be nicer to make it work with a vanilla relx script.

I did this through the use of relx startup hooks and had a cuttelfish script that gets called before the application is started up. It firstly generates the configs with cuttelfish and then symlinks the resulting app config and vm_args files to the basic relx generated ones. This overrides some of the config that would have already been done in the relx script, such as NODENAME and PIPE_DIR, with new values determined by node name in the generated config.

We are currently using this feature for building Riak 3.0 and it works reliably - with the vanilla relx script we are able to use things such as the hooks and extensions. However, it is quite a way from being production ready, so I'm creating this PR so the proposed change can be scrutinised before being taken forward.